### PR TITLE
Add support to return the selected index for onValueChange event

### DIFF
--- a/lib/src/main/kotlin/com/chargemap/compose/numberpicker/ListItemPicker.kt
+++ b/lib/src/main/kotlin/com/chargemap/compose/numberpicker/ListItemPicker.kt
@@ -36,7 +36,7 @@ fun <T> ListItemPicker(
     modifier: Modifier = Modifier,
     label: (T) -> String = { it.toString() },
     value: T,
-    onValueChange: (T) -> Unit,
+    onValueChange: (T, Int) -> Unit,
     dividersColor: Color = MaterialTheme.colors.primary,
     list: List<T>,
     textStyle: TextStyle = LocalTextStyle.current,
@@ -90,10 +90,9 @@ fun <T> ListItemPicker(
                             }
                         ).endState.value
 
-                        val result = list.elementAt(
-                            getItemIndexForOffset(list, value, endValue, halfNumbersColumnHeightPx)
-                        )
-                        onValueChange(result)
+                        val index = getItemIndexForOffset(list, value, endValue, halfNumbersColumnHeightPx)
+                        val result = list.elementAt(index)
+                        onValueChange(result, index)
                         animatedOffset.snapTo(0f)
                     }
                 }

--- a/lib/src/main/kotlin/com/chargemap/compose/numberpicker/NumberPicker.kt
+++ b/lib/src/main/kotlin/com/chargemap/compose/numberpicker/NumberPicker.kt
@@ -24,7 +24,7 @@ fun NumberPicker(
         modifier = modifier,
         label = label,
         value = value,
-        onValueChange = onValueChange,
+        onValueChange = { value, index -> onValueChange(value) },
         dividersColor = dividersColor,
         list = range.toList(),
         textStyle = textStyle,

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ var state by remember { mutableStateOf(possibleValues[0]) }
 ListItemPicker(
     label = { it },
     value = state,
-    onValueChange = { state = it },
+    onValueChange = { value, index -> state = value },
     list = possibleValues
 )
 

--- a/sample/src/main/kotlin/com/chargemap/android/sample/MainActivityUI.kt
+++ b/sample/src/main/kotlin/com/chargemap/android/sample/MainActivityUI.kt
@@ -184,7 +184,7 @@ private fun DoublesPicker() {
     ListItemPicker(
         label = { it.toString() },
         value = state,
-        onValueChange = { state = it },
+        onValueChange = { value, index -> state = value },
         list = possibleValues,
         textStyle = TextStyle(),
         selectedTextStyle = TextStyle(fontWeight = FontWeight.Bold)
@@ -198,7 +198,7 @@ private fun FruitPicker() {
     ListItemPicker(
         label = { it },
         value = state,
-        onValueChange = { state = it },
+        onValueChange = { value, index -> state = value },
         list = possibleValues
     )
 }
@@ -206,11 +206,11 @@ private fun FruitPicker() {
 @Composable
 private fun IntRangePicker() {
     val possibleValues = (-5..10).toList()
-    var value by remember { mutableStateOf(possibleValues[0]) }
+    var state by remember { mutableStateOf(possibleValues[0]) }
     ListItemPicker(
         label = { it.toString() },
-        value = value,
-        onValueChange = { value = it },
+        value = state,
+        onValueChange = { value, index -> state = value },
         list = possibleValues
     )
 }

--- a/sample/src/main/kotlin/com/chargemap/android/sample/PreviewComponents.kt
+++ b/sample/src/main/kotlin/com/chargemap/android/sample/PreviewComponents.kt
@@ -157,7 +157,7 @@ private fun DoublesPickerPreview() {
     ListItemPicker(
         label = { it.toString() },
         value = state,
-        onValueChange = { state = it },
+        onValueChange = { value, index -> state = value },
         list = possibleValues,
         textStyle = TextStyle(Color.White),
         selectedTextStyle = TextStyle(Color.White, fontWeight = FontWeight.Bold)
@@ -172,7 +172,7 @@ private fun FruitPickerPreview() {
     ListItemPicker(
         label = { it },
         value = state,
-        onValueChange = { state = it },
+        onValueChange = { value, index -> state = value },
         list = possibleValues
     )
 }
@@ -181,11 +181,11 @@ private fun FruitPickerPreview() {
 @Composable
 private fun IntRangePickerPreview() {
     val possibleValues = (-5..10).toList()
-    var value by remember { mutableStateOf(possibleValues[0]) }
+    var state by remember { mutableStateOf(possibleValues[0]) }
     ListItemPicker(
         label = { it.toString() },
-        value = value,
-        onValueChange = { value = it },
+        value = state,
+        onValueChange = { value, index -> state = value },
         list = possibleValues,
         textStyle = TextStyle(Color.White)
     )


### PR DESCRIPTION
## What happened 👀

`onValueChange` event of the base `ListItemPicker` does not provide the `selected index`. There is a need to provide the selected index for further logic.

## Insight 📝

- Add new `index` as Int into the return of `onValueChange` event.

## Proof Of Work 📹

```
val possibleValues = listOf("🍎", "🍊", "🍉", "🥭", "🍈", "🍇", "🍍")
var state by remember { mutableStateOf(possibleValues[0]) }
ListItemPicker(
    label = { it },
    value = state,
    onValueChange = { value, index -> state = value },
    list = possibleValues
)
```

